### PR TITLE
Use default C++ standard.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sarsop
 Type: Package
 Title: Approximate POMDP Planning Software
-Version: 0.6.14
+Version: 0.6.15
 Authors@R: c(
     person("Carl", "Boettiger", 
             email = "cboettig@gmail.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## v0.6.15
+
+* Remove CXX=CXX11 from Makevars. This should also fix problems with CRAN
+  special check setups.
+
 ## v0.6.14 
 
 * Patch for Apple's sprintf -> snprintf requirements

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,3 @@
-CXX_STD=CXX11
 INSTDIR=../inst/bin
 
 PKG_CPPFLAGS=-Iappl-0.96 \


### PR DESCRIPTION
This should also fix problems with CRAN special check setups.